### PR TITLE
feat: configure anon access via env vars

### DIFF
--- a/charts/nexus/templates/deployment.yaml
+++ b/charts/nexus/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
             configMapKeyRef:
               name: nexus
               key: context.path
+        {{- range $key, $value := .Values.env }}
+        - name: {{ $key }}
+          value: "{{ $value }}"
+        {{- end }}
         lifecycle:
           postStart:
             exec:

--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -20,6 +20,7 @@ resources:
   # requests:
     # cpu: 100m
     # memory: 2Gi
+env:
 readinessProbe:
   initialDelaySeconds: 30
   periodSeconds: 30

--- a/postStart.sh
+++ b/postStart.sh
@@ -75,5 +75,7 @@ for i in "${REPOS[@]}"; do
 done
 
 createOrUpdateAndRun maven-group /opt/sonatype/nexus/maven-group.json
-createOrUpdateAndRun disable-anonymous-access /opt/sonatype/nexus/disable-anonymous-access.json
 
+if [ -z "${ENABLE_ANONYMOUS_ACCESS}" ]; then
+  createOrUpdateAndRun disable-anonymous-access /opt/sonatype/nexus/disable-anonymous-access.json
+fi


### PR DESCRIPTION
We want to keep anonymous access to Nexus since it's on the internal network and it simplifies using it.
This also enables passing env vars to Nexus.