### PR TITLE
chore: update the nexus docker image to version 3.21.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonatype/nexus3:3.20.1
+FROM sonatype/nexus3:3.21.2
 
 COPY *.json /opt/sonatype/nexus/
 COPY repositories /opt/sonatype/nexus/repositories


### PR DESCRIPTION
Following a critical CVE  allowing an RCE (even as anonymous) on Nexus 3.x, up to and including 3.21.1,