### PR TITLE
Revert "chore: update the nexus docker image to version 3.21.2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonatype/nexus3:3.21.2
+FROM sonatype/nexus3:3.20.1
 
 COPY *.json /opt/sonatype/nexus/
 COPY repositories /opt/sonatype/nexus/repositories


### PR DESCRIPTION
Reverts jenkins-x-charts/nexus#48

This change caused this issue https://github.com/jenkins-x-charts/nexus/issues/49 so we need to revert until we address the problem.  

/cc @doulba @ccojocar 