### PR TITLE
fix: Delete old pod before creating new one on upgrade

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,9 @@ approvers:
 - ccojocar
 - garethjevans
 - pmuir
+- abayer
+- dgozalo
+- hferentschik
 reviewers:
 - rawlingsj
 - jstrachan
@@ -14,3 +17,6 @@ reviewers:
 - ccojocar
 - garethjevans
 - pmuir
+- abayer
+- dgozalo
+- hferentschik

--- a/nexus/templates/deployment.yaml
+++ b/nexus/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       app: {{ template "nexus.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
This should hopefully deal with the problem of the new pod being unable to come online due to the old pod still having the PVC mounted.

fixes https://github.com/jenkins-x/jx/issues/7115

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>