### PR TITLE
fix: Bump version and remove scripting usage in Nexus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonatype/nexus3:3.22.1
+FROM sonatype/nexus3:3.24.0
 
 COPY *.json /opt/sonatype/nexus/
 COPY maven-proxy-repositories /opt/sonatype/nexus/maven-proxy-repositories

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM sonatype/nexus3:3.20.1
+FROM sonatype/nexus3:3.22.1
 
 COPY *.json /opt/sonatype/nexus/
-COPY repositories /opt/sonatype/nexus/repositories
+COPY maven-proxy-repositories /opt/sonatype/nexus/maven-proxy-repositories
+COPY npmjs-proxy-repositories /opt/sonatype/nexus/npmjs-proxy-repositories
 COPY postStart.sh /opt/sonatype/nexus/
 
 USER root
 RUN chgrp -R 0 /nexus-data
 RUN chmod -R g+rw /nexus-data
 RUN find /nexus-data -type d -exec chmod g+x {} +
-    
-    
+

--- a/OWNERS
+++ b/OWNERS
@@ -20,3 +20,4 @@ reviewers:
 - abayer
 - dgozalo
 - hferentschik
+- deanesmith

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Sonatype Nexus 3.x Chart
 
-Nexus is a repository for storing and caching artifacts.
+Nexus is a repository for storing and caching artifacts.  Based on the initial work done upstream in the kubernetes chart repo [here](https://github.com/kubernetes/charts/tree/1516468/stable/sonatype-nexus).
 
-Based on the initial work done upstream in the kubernetes chart repo [here](https://github.com/kubernetes/charts/tree/1516468/stable/sonatype-nexus) but there are some significant changes happening so we will maintain a Nexus chart here until upstream settles dowm and we can contribute our changes.
+This chart is deployed when installing Jenkins X on a Kubernetes cluster.  Refer to the [Jenkins X Documentation](https://jenkins-x.io/docs/) for more information.

--- a/admin_password.json
+++ b/admin_password.json
@@ -1,5 +1,0 @@
-{
-    "name": "admin_password",
-    "type": "groovy",
-    "content": "String pass = new File('/opt/sonatype/nexus/config/password').text\nif (!pass) { throw new Exception('No default admin password secret found')}\nsecurity.securitySystem.changePassword('admin',pass.trim())"
-}

--- a/disable-anonymous-access.json
+++ b/disable-anonymous-access.json
@@ -1,5 +1,11 @@
 {
-    "name": "disable-anonymous-access",
-    "type": "groovy",
-    "content": "security.setAnonymousAccess(false)"
+    "userId": "anonymous",
+    "firstName": "Anonymous",
+    "lastName": "User",
+    "emailAddress": "anonymous@example.org",
+    "status": "disabled",
+    "source": "default",
+    "roles": [
+        "nx-anonymous"
+    ]
 }

--- a/maven-group-repositories/maven-group.json
+++ b/maven-group-repositories/maven-group.json
@@ -1,0 +1,11 @@
+{
+  "name": "maven-group",
+  "online": true,
+  "storage": {
+    "blobStoreName": "default",
+    "strictContentTypeValidation": true
+  },
+  "group": {
+    "memberNames": ["maven-public","maven-central", "maven-releases", "maven-snapshot", "spring-milestone", "spring-release", "jitpack", "jenkins-release", "maven-jenkinsci", "jenkins-public", "plugins-gradle"]
+  }
+}

--- a/maven-group.json
+++ b/maven-group.json
@@ -1,5 +1,0 @@
-{
-    "name": "maven-group",
-    "type": "groovy",
-    "content": "def name='maven-group'\ndef members = ['maven-public','maven-central', 'maven-releases', 'maven-snapshots', 'spring-milestone', 'spring-release', 'jitpack', 'jenkins-release', 'maven-jenkinsci', 'jenkins-public', 'plugins-gradle']\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenGroup(name, members) }"
-}

--- a/maven-proxy-repositories/jenkins-public.json
+++ b/maven-proxy-repositories/jenkins-public.json
@@ -1,0 +1,25 @@
+{
+  "name": "jenkins-public",
+  "online": true,
+  "storage": {
+    "blobStoreName": "default",
+    "strictContentTypeValidation": true
+  },
+  "proxy": {
+    "remoteUrl": "https://repo.jenkins-ci.org/public/",
+    "contentMaxAge": -1,
+    "metadataMaxAge": 1440
+  },
+  "negativeCache": {
+    "enabled": true,
+    "timeToLive": 1440
+  },
+  "httpClient": {
+    "blocked": false,
+    "autoBlock": true
+  },
+  "maven": {
+    "versionPolicy": "RELEASE",
+    "layoutPolicy": "STRICT"
+  }
+}

--- a/maven-proxy-repositories/jenkins-release.json
+++ b/maven-proxy-repositories/jenkins-release.json
@@ -1,0 +1,25 @@
+{
+  "name": "jenkins-release",
+  "online": true,
+  "storage": {
+    "blobStoreName": "default",
+    "strictContentTypeValidation": true
+  },
+  "proxy": {
+    "remoteUrl": "http://repo.jenkins-ci.org/releases/",
+    "contentMaxAge": -1,
+    "metadataMaxAge": 1440
+  },
+  "negativeCache": {
+    "enabled": true,
+    "timeToLive": 1440
+  },
+  "httpClient": {
+    "blocked": false,
+    "autoBlock": true
+  },
+  "maven": {
+    "versionPolicy": "RELEASE",
+    "layoutPolicy": "STRICT"
+  }
+}

--- a/maven-proxy-repositories/jitpack.json
+++ b/maven-proxy-repositories/jitpack.json
@@ -1,0 +1,25 @@
+{
+  "name": "jitpack",
+  "online": true,
+  "storage": {
+    "blobStoreName": "default",
+    "strictContentTypeValidation": true
+  },
+  "proxy": {
+    "remoteUrl": "https://jitpack.io",
+    "contentMaxAge": -1,
+    "metadataMaxAge": 1440
+  },
+  "negativeCache": {
+    "enabled": true,
+    "timeToLive": 1440
+  },
+  "httpClient": {
+    "blocked": false,
+    "autoBlock": true
+  },
+  "maven": {
+    "versionPolicy": "RELEASE",
+    "layoutPolicy": "STRICT"
+  }
+}

--- a/maven-proxy-repositories/maven-jenkinsci.json
+++ b/maven-proxy-repositories/maven-jenkinsci.json
@@ -1,0 +1,25 @@
+{
+  "name": "maven-jenkinsci",
+  "online": true,
+  "storage": {
+    "blobStoreName": "default",
+    "strictContentTypeValidation": true
+  },
+  "proxy": {
+    "remoteUrl": "https://repo.jenkins-ci.org/releases/",
+    "contentMaxAge": -1,
+    "metadataMaxAge": 1440
+  },
+  "negativeCache": {
+    "enabled": true,
+    "timeToLive": 1440
+  },
+  "httpClient": {
+    "blocked": false,
+    "autoBlock": true
+  },
+  "maven": {
+    "versionPolicy": "RELEASE",
+    "layoutPolicy": "STRICT"
+  }
+}

--- a/maven-proxy-repositories/plugins-gradle.json
+++ b/maven-proxy-repositories/plugins-gradle.json
@@ -1,0 +1,25 @@
+{
+  "name": "plugins-gradle",
+  "online": true,
+  "storage": {
+    "blobStoreName": "default",
+    "strictContentTypeValidation": true
+  },
+  "proxy": {
+    "remoteUrl": "https://plugins.gradle.org/m2",
+    "contentMaxAge": -1,
+    "metadataMaxAge": 1440
+  },
+  "negativeCache": {
+    "enabled": true,
+    "timeToLive": 1440
+  },
+  "httpClient": {
+    "blocked": false,
+    "autoBlock": true
+  },
+  "maven": {
+    "versionPolicy": "RELEASE",
+    "layoutPolicy": "STRICT"
+  }
+}

--- a/maven-proxy-repositories/spring-milestone.json
+++ b/maven-proxy-repositories/spring-milestone.json
@@ -1,0 +1,25 @@
+{
+  "name": "spring-milestone",
+  "online": true,
+  "storage": {
+    "blobStoreName": "default",
+    "strictContentTypeValidation": true
+  },
+  "proxy": {
+    "remoteUrl": "https://repo.spring.io/milestone/",
+    "contentMaxAge": -1,
+    "metadataMaxAge": 1440
+  },
+  "negativeCache": {
+    "enabled": true,
+    "timeToLive": 1440
+  },
+  "httpClient": {
+    "blocked": false,
+    "autoBlock": true
+  },
+  "maven": {
+    "versionPolicy": "RELEASE",
+    "layoutPolicy": "STRICT"
+  }
+}

--- a/maven-proxy-repositories/spring-release.json
+++ b/maven-proxy-repositories/spring-release.json
@@ -1,0 +1,25 @@
+{
+  "name": "spring-release",
+  "online": true,
+  "storage": {
+    "blobStoreName": "default",
+    "strictContentTypeValidation": true
+  },
+  "proxy": {
+    "remoteUrl": "https://repo.spring.io/release/",
+    "contentMaxAge": -1,
+    "metadataMaxAge": 1440
+  },
+  "negativeCache": {
+    "enabled": true,
+    "timeToLive": 1440
+  },
+  "httpClient": {
+    "blocked": false,
+    "autoBlock": true
+  },
+  "maven": {
+    "versionPolicy": "RELEASE",
+    "layoutPolicy": "STRICT"
+  }
+}

--- a/npmjs-proxy-repositories/npmjs-registry.json
+++ b/npmjs-proxy-repositories/npmjs-registry.json
@@ -1,0 +1,25 @@
+{
+  "name": "npmjs-registry",
+  "online": true,
+  "storage": {
+    "blobStoreName": "default",
+    "strictContentTypeValidation": true
+  },
+  "proxy": {
+    "remoteUrl": "https://registry.npmjs.org",
+    "contentMaxAge": -1,
+    "metadataMaxAge": 1440
+  },
+  "negativeCache": {
+    "enabled": true,
+    "timeToLive": 1440
+  },
+  "httpClient": {
+    "blocked": false,
+    "autoBlock": true
+  },
+  "maven": {
+    "versionPolicy": "RELEASE",
+    "layoutPolicy": "STRICT"
+  }
+}

--- a/postStart.sh
+++ b/postStart.sh
@@ -15,6 +15,7 @@ find /nexus-data -type d -exec chmod g+x {} +
 NEXUS_BASE_DIR="/opt/sonatype/nexus"
 NEXUS_MAVEN_REPO_DIR="${NEXUS_BASE_DIR}/maven-proxy-repositories"
 NEXUS_NPMJS_REPO_DIR="${NEXUS_BASE_DIR}/npmjs-proxy-repositories"
+NEXUS_MAVEN_GROUP_DIR="${NEXUS_BASE_DIR}/maven-group-repositories"
 USERNAME="admin"
 PASSWORD="admin123"
 PASSWORD_FROM_FILE="$(cat "${NEXUS_BASE_DIR}"/config/password || true)"
@@ -77,6 +78,13 @@ echo "Creating npmjs proxy repositories from json"
 mapfile -t REPOS < <(find "${NEXUS_NPMJS_REPO_DIR}" -maxdepth 1 -type f -name "*json*")
 for repo in "${REPOS[@]}"; do
     runCurlFromJsonFile "${repo}" "service/rest/beta/repositories/npm/proxy" POST
+done
+
+# For each maven group repository json file, create the repo via the Nexus API.
+echo "Creating maven group repositories from json"
+mapfile -t REPOS < <(find "${NEXUS_MAVEN_GROUP_DIR}" -maxdepth 1 -type f -name "*json*")
+for repo in "${REPOS[@]}"; do
+    runCurlFromJsonFile "${repo}" "service/rest/beta/repositories/maven/group" POST
 done
 
 # It is not possible at this time to disable anonymous access at the server level via API.

--- a/postStart.sh
+++ b/postStart.sh
@@ -7,42 +7,37 @@ until curl --output /dev/null --silent --head --fail http://${HOST}/; do
   sleep 5
 done
 
+
 chgrp -R 0 /nexus-data
 chmod -R g+rw /nexus-data
 find /nexus-data -type d -exec chmod g+x {} +
 
 NEXUS_BASE_DIR="/opt/sonatype/nexus"
-NEXUS_REPO_DIR="${NEXUS_BASE_DIR}/repositories"
+NEXUS_MAVEN_REPO_DIR="${NEXUS_BASE_DIR}/maven-proxy-repositories"
+NEXUS_NPMJS_REPO_DIR="${NEXUS_BASE_DIR}/npmjs-proxy-repositories"
 USERNAME="admin"
 PASSWORD="admin123"
 PASSWORD_FROM_FILE="$(cat "${NEXUS_BASE_DIR}"/config/password || true)"
-declare -a SCRIPT_LIST
 
 function die() {
     echo "ERROR: $*" 1>&2
     exit 1
 }
 
-function createOrUpdateAndRun() {
-    local scriptFile scriptName scriptNameRegex
-    scriptFile="${1}.json"
-    scriptName="$(basename "${1}")"
-    scriptNameRegex=" ${scriptName} "
-    if [ "${#SCRIPT_LIST[@]}" = 0 ] || [[ ! " ${SCRIPT_LIST[*]} " =~ ${scriptNameRegex} ]]; then
-        echo "Creating ${scriptName} repository script"
-        curl --fail -X POST -u "${USERNAME}":"${PASSWORD}" --header "Content-Type: application/json" "http://${HOST}/service/rest/v1/script/" -d @"${scriptFile}"
-    else
-        echo "Updating ${scriptName} repository script"
-        curl --fail -X PUT -u "${USERNAME}":"${PASSWORD}" --header "Content-Type: application/json" "http://${HOST}/service/rest/v1/script/${scriptName}" -d @"${scriptFile}"
-    fi
-    echo "Running ${scriptName} repository script"
-    curl --fail -X POST -u "${USERNAME}":"${PASSWORD}" --header "Content-Type: text/plain" "http://${HOST}/service/rest/v1/script/${scriptName}/run"
-    echo
-}
+# Call the Nexus API for the specified repository
+function runCurlFromJsonFile() {
+    local jsonFile
+    local service
+    local body
+    local method
+    jsonFile="${1}"
+    service="${2}"
+    method="${3}"
+    body="$(cat "${jsonFile}")"
 
-function setScriptList() {
-    # initialising the scripts already present once and assuming that there no duplicate script names in the scripts that follow
-    mapfile -t SCRIPT_LIST < <(curl --fail -s -u "${USERNAME}":"${PASSWORD}" http://"${HOST}"/service/rest/v1/script | grep -oE "\"name\" : \"[^\"]+" | sed 's/"name" : "//')
+    if  ! curl --fail -X "${method}" -u "${USERNAME}":"${PASSWORD}" "http://${HOST}/${service}" -H "accept:application/json" -H "Content-Type:application/json" -d "${body//[$'\t\r\n']}"; then
+        echo "Error calling Nexus API for http://${HOST}/${service} to add repository from ${jsonFile}"
+    fi
 }
 
 function setPasswordFromFile() {
@@ -56,15 +51,13 @@ function setPasswordFromFile() {
 
 if curl --fail --silent -u "${USERNAME}":"${PASSWORD}" http://"${HOST}"/service/metrics/ping; then
     echo "Login to nexus succeeded. Default password worked. Updating password if available..."
-    setScriptList
-    createOrUpdateAndRun "${NEXUS_BASE_DIR}"/admin_password
+    curl --fail -X PUT -u "${USERNAME}":"${PASSWORD}" "http://${HOST}/service/rest/beta/security/users/admin/change-password" --header "Content-Type: text/plain" -d "${PASSWORD_FROM_FILE}"
     setPasswordFromFile
 elif [ -n "${PASSWORD_FROM_FILE}" ]; then
     setPasswordFromFile
     echo "Default password failed. Checking password file..."
     if curl --fail --silent -u "${USERNAME}":"${PASSWORD}" http://"${HOST}"/service/metrics/ping; then
         echo "Login to nexus succeeded. Password from secret file worked."
-        setScriptList
     else
         die "Login to nexus failed. Tried both the default password and the provided password secret file."
     fi
@@ -72,14 +65,23 @@ else
     die "Login to nexus failed. Tried the default password only since no password secret file was provided."
 fi
 
-
-mapfile -t REPOS < <(find "${NEXUS_REPO_DIR}" -maxdepth 1 -type f -name "*json*" | sed -e 's/\..*$//')
+# For each maven repository proxy json file, create the repo proxy via the Nexus API.
+echo "Creating maven proxy repositories from json"
+mapfile -t REPOS < <(find "${NEXUS_MAVEN_REPO_DIR}" -maxdepth 1 -type f -name "*json*")
 for repo in "${REPOS[@]}"; do
-    createOrUpdateAndRun "${repo}"
+    runCurlFromJsonFile "${repo}" "service/rest/beta/repositories/maven/proxy" POST
 done
 
-createOrUpdateAndRun "${NEXUS_BASE_DIR}"/maven-group
+# For each npmjs proxy repository json file, create the repo proxy via the Nexus API.
+echo "Creating npmjs proxy repositories from json"
+mapfile -t REPOS < <(find "${NEXUS_NPMJS_REPO_DIR}" -maxdepth 1 -type f -name "*json*")
+for repo in "${REPOS[@]}"; do
+    runCurlFromJsonFile "${repo}" "service/rest/beta/repositories/npm/proxy" POST
+done
 
-if [ -z "${ENABLE_ANONYMOUS_ACCESS}" ]; then
-  createOrUpdateAndRun "${NEXUS_BASE_DIR}"/disable-anonymous-access
+# It is not possible at this time to disable anonymous access at the server level via API.
+# By disabling the anonymous user account, it has the same result.
+if [ -z "${ENABLE_ANONYMOUS_ACCESS}" ] || [ "${ENABLE_ANONYMOUS_ACCESS}" = "false" ]; then
+    echo "Disabling the anonymous account"
+    runCurlFromJsonFile "${NEXUS_BASE_DIR}"/disable-anonymous-access.json "service/rest/beta/security/users/anonymous" PUT
 fi

--- a/repositories/gradle-distributions.json
+++ b/repositories/gradle-distributions.json
@@ -1,5 +1,0 @@
-{
-  "name": "gradle-distributions",
-  "type": "groovy",
-  "content": "def name='gradle-distributions'\ndef url='https://services.gradle.org/distributions/'\nif(!repository.getRepositoryManager().exists(name)) { repository.createRawProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
-}

--- a/repositories/jenkins-public.json
+++ b/repositories/jenkins-public.json
@@ -1,5 +1,0 @@
-{
-  "name": "jenkins-public",
-  "type": "groovy",
-  "content": "def name='jenkins-public'\ndef url='https://repo.jenkins-ci.org/public/'\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
-}

--- a/repositories/jenkins-release.json
+++ b/repositories/jenkins-release.json
@@ -1,5 +1,0 @@
-{
-  "name": "jenkins-release",
-  "type": "groovy",
-  "content": "def name='jenkins-release'\ndef url='http://repo.jenkins-ci.org/releases/'\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
-}

--- a/repositories/jitpack.json
+++ b/repositories/jitpack.json
@@ -1,5 +1,0 @@
-{
-  "name": "jitpack",
-  "type": "groovy",
-  "content": "def name='jitpack'\ndef url='https://jitpack.io'\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
-}

--- a/repositories/maven-jenkinsci.json
+++ b/repositories/maven-jenkinsci.json
@@ -1,5 +1,0 @@
-{
-  "name": "maven-jenkinsci",
-  "type": "groovy",
-  "content": "def name='maven-jenkinsci'\ndef url='https://repo.jenkins-ci.org/releases/'\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
-}

--- a/repositories/npmjs-registry.json
+++ b/repositories/npmjs-registry.json
@@ -1,5 +1,0 @@
-{
-  "name": "npmjs-registry",
-  "type": "groovy",
-  "content": "def name='npmjs-registry'\ndef url='https://registry.npmjs.org'\nif(!repository.getRepositoryManager().exists(name)) { repository.createNpmProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
-}

--- a/repositories/plugins-gradle.json
+++ b/repositories/plugins-gradle.json
@@ -1,5 +1,0 @@
-{
-  "name": "plugins-gradle",
-  "type": "groovy",
-  "content": "def name='plugins-gradle'\ndef url='https://plugins.gradle.org/m2'\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
-}

--- a/repositories/spring-milestone.json
+++ b/repositories/spring-milestone.json
@@ -1,5 +1,0 @@
-{
-  "name": "spring-milestone",
-  "type": "groovy",
-  "content": "def name='spring-milestone'\ndef url='https://repo.spring.io/milestone/'\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
-}

--- a/repositories/spring-release.json
+++ b/repositories/spring-release.json
@@ -1,5 +1,0 @@
-{
-  "name": "spring-release",
-  "type": "groovy",
-  "content": "def name='spring-release'\ndef url='https://repo.spring.io/release/'\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
-}


### PR DESCRIPTION
Since current versions of Nexus have scripting disabled by default this PR removes scripting in favor of API usage.  When attempting previously, the absence of parity with Nexus API capabilities and scripting capabilities has been a blocker.  This is another attempt which includes the maven-group repository. Addresses https://github.com/jenkins-x-charts/nexus/issues/49